### PR TITLE
BE-346: update validate challenger rule

### DIFF
--- a/contracts/LiBA.sol
+++ b/contracts/LiBA.sol
@@ -525,7 +525,7 @@ contract LiBA is Ownable, Pausable, TokenUtil, PullPayment, WhitelistedRole {
             address winner = winners[i];
             Bid storage winnerBid = bidsByUser[winner][_auctionId];
 
-            // Too much winners
+            // Too many winners
             if (totalValue >= auction.value && i < winners.length) {
                 return true;
             }


### PR DESCRIPTION
There four cases
1. too much winners
2. not enough winners
3. winner order is not right
4. winner is not selected